### PR TITLE
Fix slashes on Windows

### DIFF
--- a/flask_cache_bust/__init__.py
+++ b/flask_cache_bust/__init__.py
@@ -27,8 +27,9 @@ def init_cache_busting(app):
                 version = hashlib.md5(f.read()).hexdigest()[:7]
 
             # add version
-            unbusted = os.path.relpath(rooted_filename, static_folder)
-            busted = os.path.join(version, unbusted)
+            # Replace \ with /, since web URLs will always use / (fixes issues on Windows)
+            unbusted = os.path.relpath(rooted_filename, static_folder).replace('\\', '/')
+            busted = os.path.join(version, unbusted).replace('\\', '/')
 
             # save computation to tables
             bust_table[unbusted] = busted


### PR DESCRIPTION
On Windows, the `bust_table` and `unbust_table` are filled with paths that use `\` as the directory separator. But since URLs use `/` as their directory separator, no paths ever match the bust/unbust table.

This replaces all slashes with web friendly ones. Tested on Windows 10 without any issues.
